### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -37,7 +37,8 @@ def index():
     return render_template('index.html')
 
 def run_flask(port):
-    app.run(debug=True, use_reloader=False, port=port)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode, use_reloader=False, port=port)
 
 if __name__ == "__main__":
     config = read_config_from_file()


### PR DESCRIPTION
Fixes [https://github.com/LeviSnoot/FNFest-Status/security/code-scanning/1](https://github.com/LeviSnoot/FNFest-Status/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode when deployed in a production environment. This can be achieved by using an environment variable to control the debug mode. The `app.run` call should be modified to check the environment and set the `debug` parameter accordingly.

1. Import the `os` module if not already imported.
2. Modify the `run_flask` function to set the `debug` parameter based on an environment variable.
3. Update the `app.run` call to use the `debug` parameter based on the environment variable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
